### PR TITLE
Fixes Android compile error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,11 @@ set(cryptopp_SOURCES
     ${cryptopp_SOURCES}
     )
 
+if(ANDROID)
+    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+    list(APPEND cryptopp_SOURCES ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+endif()
+
 set(cryptopp_SOURCES_ASM)
 
 if (MSVC AND NOT DISABLE_ASM)


### PR DESCRIPTION
This PR fixes Android compile error due to failing to identify `cpu-features.h`. Once this PR accepted, I will update the corresponded hunter package.

```
  % cmake --build Build
  [0/11] Performing build step for 'cryptopp-Release'
  [1/157] Building CXX object CMakeFiles/cryptopp-static.dir/cpu.cpp.o
  FAILED: CMakeFiles/cryptopp-static.dir/cpu.cpp.o 
  /Users/username/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=x86_64-none-linux-android24 --gcc-toolchain=/Users/username/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64 --sysroot=/Users/username/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/sysroot  -I/Users/username/.hunter/_Base/4231132/49e328c/fe0ebc2/Build/cryptopp/Source -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -O2 -DNDEBUG  -fPIC -DCRYPTOPP_DISABLE_MIXED_ASM -DCRYPTOPP_DISABLE_ASM -DCRYPTOPP_DISABLE_SSSE3 -std=gnu++17 -MD -MT CMakeFiles/cryptopp-static.dir/cpu.cpp.o -MF CMakeFiles/cryptopp-static.dir/cpu.cpp.o.d -o CMakeFiles/cryptopp-static.dir/cpu.cpp.o -c /Users/username/.hunter/_Base/4231132/49e328c/fe0ebc2/Build/cryptopp/Source/cpu.cpp
  /Users/username/.hunter/_Base/4231132/49e328c/fe0ebc2/Build/cryptopp/Source/cpu.cpp:51:11: fatal error: 'cpu-features.h' file not found
  # include "cpu-features.h"
            ^~~~~~~~~~~~~~~~
  1 error generated.
  [16/157] Building CXX object CMakeFiles/cryptopp-static.dir/blake2.cpp.o
  ninja: build stopped: subcommand failed.
  FAILED: cryptopp-Release-prefix/src/cryptopp-Release-stamp/cryptopp-Release-build 
  cd /Users/username/.hunter/_Base/4231132/49e328c/fe0ebc2/Build/cryptopp/Build/cryptopp-Release-prefix/src/cryptopp-Release-build && /Users/username/Library/Android/sdk/cmake/3.18.1/bin/cmake --build . --config Release -- -j16 && /Users/username/Library/Android/sdk/cmake/3.18.1/bin/cmake -E touch /Users/username/.hunter/_Base/4231132/49e328c/fe0ebc2/Build/cryptopp/Build/cryptopp-Release-prefix/src/cryptopp-Release-stamp/cryptopp-Release-build
  ninja: build stopped: subcommand failed.
```